### PR TITLE
Add custom fields to the dataset create/edit page

### DIFF
--- a/ckanext/cnra_schema/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/cnra_schema/templates/scheming/package/snippets/package_form.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block metadata_fields %}
+  {% block package_metadata_fields_custom %}
+    {% block custom_fields %}
+      {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
+    {% endblock %}
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
## Description
This PR adds custom fields to the dataset create/edit page. The dcat harvester adds custom fields like `spatial` when harvesting. Without the change from this PR the `spatial` field could be removed from the dataset page the next time the dataset is updated.