### PR TITLE
 [ESN-255]Added styling for dl html tag to reduce spacing 

### DIFF
--- a/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
+++ b/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
@@ -1,4 +1,4 @@
-.composite_display_snippet_dl {
+.composite-display-snippet_dl {
     margin-bottom: -10px;
     margin-top: 10px;
 }

--- a/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
+++ b/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
@@ -1,0 +1,4 @@
+.cnra_composite_display_snippet_dl {
+    margin-bottom: -10px;
+    margin-top: 10px;
+}

--- a/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
+++ b/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
@@ -1,4 +1,4 @@
-.cnra_composite_display_snippet_dl {
+.composite_display_snippet_dl {
     margin-bottom: -10px;
     margin-top: 10px;
 }

--- a/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
+++ b/ckanext/cnra_schema/fanstatic/css/composite_display_snippet.css
@@ -1,4 +1,4 @@
-.composite-display-snippet_dl {
+.composite-display-snippet {
     margin-bottom: -10px;
     margin-top: 10px;
 }

--- a/ckanext/cnra_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/cnra_schema/templates/scheming/package/snippets/additional_info.html
@@ -16,6 +16,8 @@
 
 {% block package_additional_info %}
 
+  {% resource 'cnra_schema/css/composite_display_snippet.css' %}
+
   {%- for field in schema.dataset_fields -%}
     {%- if field.field_name not in exclude_fields
         and field.display_snippet is not none


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-255](https://opengovinc.atlassian.net/browse/ESN-255)

## Description
<!--- Describe these changes in detail --->
This PR adds CSS styling to dl tags in CNRA's theme to remove excess spacing when viewing a dataset's metadata.


## Test Procedure
<!--- List the steps involved to test the changes --->
1. Checkout the branch for this PR and run `python setup.py develop`
2. In your ini:
 - Disable the plugin `xloader` (This is done to save storage since the harvest url has 185 datasets)
 - Enable the following plugins
```
waf_harvester
spatial_metadata
spatial_query
cnra_schema
scheming_datasets
composite
repeating
```
**NOTE**: For testing, checkout branch `javier-tello23/ESN-2555/2021-01-20/metadata-composite-field-enhancement-css` for `ckanext-comoposite` during testing. Also merge https://github.com/OpenGov-OpenData/ckanext-composite/pull/2 if this PR is approved. 

Refer to this PR: https://github.com/OpenGov-OpenData/ckanext-composite/pull/2

3. Start CKAN and navigate to the harvest page `http://127.0.0.1:5000/dataset`.
4. Create a new dataset and make sure any of the following composite fields is populate with data: 
```
Bounding Coordinate
Identification Information Citation
Point of Contact
Metadata Contact
Distributor Contact
```

## Screenshots/GIF:
![Screen Shot 2021-01-20 at 4 03 22 PM](https://user-images.githubusercontent.com/49450112/105246794-c02b5800-5b41-11eb-984e-88d6c2c7089d.png)


## Approval Criteria 
<!--- Describe the expected results of testing --->

## Submitter Checklist
- [ ] The code looks good to me (LGTM)
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
