### PR TITLE
[ESN-2555]Fix bug where "Identification Information Citation" field would not display if title is empty

### DIFF
--- a/ckanext/cnra_schema/helpers.py
+++ b/ckanext/cnra_schema/helpers.py
@@ -51,22 +51,26 @@ def is_dict_populated(package_dict_field):
     :param package_dict_field:
     :return: Boolean value depending on if the composite field is populated
     """
-    primitive_types = (str, int, float, complex, bool, bytes)
     is_dict_populated_bool = False
 
-    if isinstance(package_dict_field, dict) or isinstance(package_dict_field, list):
-        values = package_dict_field.values() if isinstance(package_dict_field, dict) else package_dict_field
-        for val in values:
+    if isinstance(package_dict_field, (dict, list)):
+        package_dict_field_values = []
+        if isinstance(package_dict_field, dict):
+            package_dict_field_values = package_dict_field.values()
+        else:
+            package_dict_field_values = package_dict_field
+
+        for val in package_dict_field_values:
             if val and isinstance(val, dict):
                 is_dict_populated_bool = is_dict_populated(val)
             elif val and isinstance(val, list):
                 is_dict_populated_bool = any((is_dict_populated(x) for x in val))
-            elif val and isinstance(val, primitive_types):
+            elif val:
                 return True
 
             if is_dict_populated_bool:
                 return True
-    elif package_dict_field and isinstance(package_dict_field, primitive_types):
+    elif package_dict_field:
         return True
 
     return False

--- a/ckanext/cnra_schema/helpers.py
+++ b/ckanext/cnra_schema/helpers.py
@@ -53,8 +53,10 @@ def is_dict_populated(package_dict_field):
     """
     primitive_types = (str, int, float, complex, bool, bytes)
     is_dict_populated_bool = False
-    if isinstance(package_dict_field, dict):
-        for val in package_dict_field.values():
+
+    if isinstance(package_dict_field, dict) or isinstance(package_dict_field, list):
+        values = package_dict_field.values() if isinstance(package_dict_field, dict) else package_dict_field
+        for val in values:
             if val and isinstance(val, dict):
                 is_dict_populated_bool = is_dict_populated(val)
             elif val and isinstance(val, list):
@@ -64,14 +66,7 @@ def is_dict_populated(package_dict_field):
 
             if is_dict_populated_bool:
                 return True
-    elif isinstance(package_dict_field, list):
-        for val in package_dict_field:
-            if val and isinstance(val, dict):
-                is_dict_populated_bool = is_dict_populated(val)
-            elif val and isinstance(val, primitive_types):
-                is_dict_populated_bool = True
-
-            if is_dict_populated_bool:
-                return True
+    elif package_dict_field and isinstance(package_dict_field, primitive_types):
+        return True
 
     return False

--- a/ckanext/cnra_schema/tests/test_helpers.py
+++ b/ckanext/cnra_schema/tests/test_helpers.py
@@ -76,6 +76,11 @@ class TestHelperFunctions(object):
 
         assert not result
 
+    def test_is_dict_populated_success_populated_field_is_dict_of_mixed_values_first_value_is_empty(self):
+        result = cnra_schema_helpers.is_dict_populated({"title": "", "onlineLinkage": ["", ""], "edition": "",
+                                                        "publicationDate": "", "geospatialDataPresentationForm": "",
+                                                        "originator": ["Amelia Earhart", "John Doe", ""]})
+
     def test_is_dict_populated_success_populated_field_is_list_of_populate_dicts(self):
         result = cnra_schema_helpers.is_dict_populated([{'a': ''}, {'b': '2'}])
 


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-2555](https://opengovinc.atlassian.net/browse/ESN-2555)

## Description
<!--- Describe these changes in detail --->
A bug was found where "Identification Information Citation" would not display if the "Title" subfield was empty. This PR fixes this bug.

## Test Procedure
<!--- List the steps involved to test the changes --->
1. Checkout the branch for this PR and run `python setup.py develop`
2. In your ini:
 - Enable the following plugins
```
waf_harvester
spatial_metadata
spatial_query
cnra_schema
scheming_datasets
composite
repeating
```

3. Start CKAN and navigate to the harvest page `http://127.0.0.1:5000/dataset`.
4. Recreate the following dataset on your local environment https://cnrastaging.ogopendata.com/dataset/test-composite
5. Make sure the field "Identification Information Citation" is displayed with and without the "Title" subfield populated.

**Unit Testing**
In the `ckanext-cnra_schema` directory, run the following command:  `nosetests --ckan --with-pylons=test.ini ckanext/cnra_schema/tests`


## Approval Criteria 
<!--- Describe the expected results of testing --->

## Submitter Checklist
- [ ] The code looks good to me (LGTM)
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
