### PR TITLE
Change display of contact email to text

### DIFF
--- a/ckanext/cnra_schema/schemas/dataset.yaml
+++ b/ckanext/cnra_schema/schemas/dataset.yaml
@@ -74,7 +74,7 @@ dataset_fields:
 - field_name: contact_email
   label: Contact Email
   form_placeholder: The email for the dataset maintainer.
-  display_snippet: email.html
+  display_snippet: text.html
   required: True
 
 ## "frequency"


### PR DESCRIPTION
Change display of contact email to text to allow multiple email addresses to be displayed correctly.