### PR TITLE
Add org schema

### DIFF
--- a/ckanext/cnra_schema/schemas/organization.yaml
+++ b/ckanext/cnra_schema/schemas/organization.yaml
@@ -1,0 +1,34 @@
+scheming_version: 1
+organization_type: organization
+about: California Natural Resources Agency (CNRA) Organization Schema
+about_url: https://github.com/OpenGov-OpenData/ckanext-cnra_schema
+
+fields:
+- field_name: title
+  label: Name
+  validators: ignore_missing unicode_safe
+  form_snippet: large_text.html
+  form_attrs:
+    data-module: slug-preview-target
+  form_placeholder: My Organization
+
+- field_name: name
+  label: URL
+  validators: not_empty unicode_safe name_validator group_name_validator
+  form_snippet: slug.html
+  form_placeholder: my-organization
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: A little information about my organization...
+
+- field_name: url
+  label: Image URL
+  form_placeholder: http://example.com/my-image.jpg
+
+- field_name: parent_organization
+  label: Parent Organization
+  display_snippet:
+  form_snippet: org_hierarchy.html
+  validators: ignore_missing


### PR DESCRIPTION
## Description
Only enable organization schema if the `hierarchy_form` plugin is enabled. This allows the CNRA schema to work with [ckanext-hierarchy](https://github.com/ckan/ckanext-hierarchy) by adding the field `Parent Organization` to the organization form.