### PR TITLE
feat: expand dataset frequency accrualPeriodicity options

### DIFF
--- a/ckanext/cnra_schema/schemas/dataset.yaml
+++ b/ckanext/cnra_schema/schemas/dataset.yaml
@@ -84,22 +84,48 @@ dataset_fields:
   choices:
   - label: Irregular
     value: Irregular
+  - label: Hourly
+    value: Hourly
   - label: Daily
     value: Daily
+  - label: Three times a week
+    value: Three times a week
+  - label: Semiweekly
+    value: Semiweekly
   - label: Weekly
     value: Weekly
+  - label: Biweekly
+    value: Biweekly
+  - label: Semimonthly
+    value: Semimonthly
+  - label: Three times a month
+    value: Three times a month
+  - label: Bimonthly
+    value: Bimonthly
   - label: Monthly
     value: Monthly
   - label: Quarterly
     value: Quarterly
+  - label: Three times a year
+    value: Three times a year
   - label: Semiannual
     value: Semiannual
   - label: Annual
     value: Annual
+  - label: Biennial
+    value: Biennial
+  - label: Triennial
+    value: Triennial
+  - label: Quadrennial
+    value: Quadrennial
   - label: Decennial
     value: Decennial
+  - label: Continuous
+    value: Continuous
   - label: Other
     value: Other
+  - label: Unknown
+    value: Unknown
   display_snippet: select.html
 
 ## "license_id"

--- a/ckanext/cnra_schema/templates/scheming/package/resource_read.html
+++ b/ckanext/cnra_schema/templates/scheming/package/resource_read.html
@@ -1,11 +1,11 @@
 {% extends "package/resource_read.html" %}
 
 {%- set exclude_fields = [
-    'name',
-    'description',
-    'url',
-    'format',
-    ] -%}
+  'name',
+  'description',
+  'url',
+  'format',
+  ] -%}
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
 
 {% block resource_additional_information_inner %}
@@ -23,14 +23,16 @@
               <th scope="col">{{ _('Description') }}</th>
             </tr>
           </thead>
-          {% for field in ddict %}
-            <tr {% if loop.index > 10 %}class="toggle-more"{% endif %}>
-              <td>{{ field.id }}</td>
-              <td>{{ field.type }}</td>
-              <td>{{ field.get('info', {}).label }}</td>
-              <td>{{ h.render_markdown(field.get('info', {}).notes) }}</td>
-            </tr>
-          {% endfor %}
+          <tbody>
+            {% for field in ddict %}
+              <tr {% if loop.index > 10 %}class="toggle-more"{% endif %}>
+                <td>{{ field.id }}</td>
+                <td>{{ field.type }}</td>
+                <td>{{ field.get('info', {}).label }}</td>
+                <td>{{ h.render_markdown(field.get('info', {}).notes) }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
         </table>
       </div>
     {% endif %}

--- a/ckanext/cnra_schema/templates/scheming/package/resource_read.html
+++ b/ckanext/cnra_schema/templates/scheming/package/resource_read.html
@@ -9,14 +9,11 @@
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
 
 {% block resource_additional_information_inner %}
-  {% set ddict=h.datastore_dictionary(res.id) %}
-  {% if res.datastore_active and h.is_data_dict_active(ddict) %}
-    <section class="module data-dictionary">
-      {% set ddict=h.datastore_dictionary(res.id) %}
+  {% if res.datastore_active %}
+    {% set ddict=h.datastore_dictionary(res.id) %}
+    {% if h.is_data_dict_active(ddict) %}
       <div class="module-content">
-        <h2>
-          {{ _('Data Dictionary') }}
-        </h2>
+        <h2>{{ _('Data Dictionary') }}</h2>
         <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
           <thead>
             <tr>
@@ -26,19 +23,18 @@
               <th scope="col">{{ _('Description') }}</th>
             </tr>
           </thead>
-          {% for f in ddict %}
-            <tr {% if loop.index > 5 %}class="toggle-more"{% endif %}>
-              <td>{{ f.id }}</td>
-              <td>{{ f.type }}</td>
-              <td>{{ f.get('info', {}).label }}</td>
-              <td>{{ h.render_markdown(f.get('info', {}).notes) }}</td>
+          {% for field in ddict %}
+            <tr {% if loop.index > 10 %}class="toggle-more"{% endif %}>
+              <td>{{ field.id }}</td>
+              <td>{{ field.type }}</td>
+              <td>{{ field.get('info', {}).label }}</td>
+              <td>{{ h.render_markdown(field.get('info', {}).notes) }}</td>
             </tr>
           {% endfor %}
         </table>
       </div>
-    </section>
+    {% endif %}
   {% endif %}
-
   <div class="module-content">
     <h2>{{ _('Additional Information') }}</h2>
     <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
@@ -79,14 +75,12 @@
             <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
           </tr>
         {%- endblock -%}
-{#
-        {%- block resource_license -%}
+        {% if res.size and res.size|int != 0 %}
           <tr>
-            <th scope="row">{{ _('License') }}</th>
-            <td>{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</td>
+            <th scope="row">{{ _('Size') }}</th>
+            <td>{{ h.localised_filesize(res.size) }}</td>
           </tr>
-        {%- endblock -%}
-#}
+        {% endif %}
         {%- block resource_fields -%}
           {%- for field in schema.resource_fields -%}
             {%- if field.field_name not in exclude_fields


### PR DESCRIPTION
# Description
Expand dataset frequency choices for accrual periodicity.

Add Hourly, Three times a week, Semiweekly, Biweekly, Semimonthly, Three times a month, Bimonthly, Three times a year, Biennial, Triennial, Quadrennial, Continuous and Unknown to match accrual periodicity vocabulary.
https://resources.data.gov/schemas/dcat-us/v1.1/iso8601_guidance/#accrualperiodicity

Also display resource file size in the Additional Information table.